### PR TITLE
feat: 기본 응답 구조 생성

### DIFF
--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ErrorException.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ErrorException.java
@@ -1,6 +1,7 @@
 package io.twogether.nbe_5_7_2_02team.global.exception;
 
 import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode;
+
 import lombok.Getter;
 
 @Getter

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ErrorException.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ErrorException.java
@@ -1,5 +1,6 @@
 package io.twogether.nbe_5_7_2_02team.global.exception;
 
+import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ExceptionAdvice.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ExceptionAdvice.java
@@ -1,5 +1,7 @@
 package io.twogether.nbe_5_7_2_02team.global.exception;
 
+import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode;
+import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ExceptionAdvice.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/exception/ExceptionAdvice.java
@@ -2,6 +2,7 @@ package io.twogether.nbe_5_7_2_02team.global.exception;
 
 import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode;
 import io.twogether.nbe_5_7_2_02team.global.response.error.ErrorResponse;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorCode.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorCode.java
@@ -1,6 +1,6 @@
-package io.twogether.nbe_5_7_2_02team.global.exception;
+package io.twogether.nbe_5_7_2_02team.global.response.error;
 
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorStatus.*;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorStatus.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorResponse.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package io.twogether.nbe_5_7_2_02team.global.exception;
+package io.twogether.nbe_5_7_2_02team.global.response.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorStatus.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/error/ErrorStatus.java
@@ -1,4 +1,4 @@
-package io.twogether.nbe_5_7_2_02team.global.exception;
+package io.twogether.nbe_5_7_2_02team.global.response.error;
 
 public enum ErrorStatus {
     BAD_REQUEST,

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
@@ -1,8 +1,9 @@
 package io.twogether.nbe_5_7_2_02team.global.response.success;
 
+import org.springframework.http.ResponseEntity;
+
 import java.net.URI;
 import java.util.Map;
-import org.springframework.http.ResponseEntity;
 
 public class BaseResponse<T> {
 
@@ -11,25 +12,34 @@ public class BaseResponse<T> {
     private String message;
     private T data;
 
-    public static <T> ResponseEntity<Map<String, Object>> of(SuccessCode code, T data,
-        URI createdLocation) {
+    public static <T> ResponseEntity<Map<String, Object>> of(
+            SuccessCode code, T data, URI createdLocation) {
         return switch (code.getStatus()) {
-            case OK -> ResponseEntity.ok(
-                buildBody(code.getCode(), code.getStatus().name(), code.getMessage(), data));
-            case CREATED -> ResponseEntity.created(createdLocation)
-                .body(buildBody(code.getCode(), code.getStatus().name(), code.getMessage(), data));
+            case OK ->
+                    ResponseEntity.ok(
+                            buildBody(
+                                    code.getCode(),
+                                    code.getStatus().name(),
+                                    code.getMessage(),
+                                    data));
+            case CREATED ->
+                    ResponseEntity.created(createdLocation)
+                            .body(
+                                    buildBody(
+                                            code.getCode(),
+                                            code.getStatus().name(),
+                                            code.getMessage(),
+                                            data));
             case NO_CONTENT -> ResponseEntity.noContent().build();
         };
     }
 
-    private static <T> Map<String, Object> buildBody(String code, String status, String message,
-        T data) {
+    private static <T> Map<String, Object> buildBody(
+            String code, String status, String message, T data) {
         return Map.of(
-            "code", code,
-            "status", status,
-            "message", message,
-            "data", data
-        );
+                "code", code,
+                "status", status,
+                "message", message,
+                "data", data);
     }
-
 }

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
@@ -1,0 +1,35 @@
+package io.twogether.nbe_5_7_2_02team.global.response.success;
+
+import java.net.URI;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+
+public class BaseResponse<T> {
+
+    private int code;
+    private String status;
+    private String message;
+    private T data;
+
+    public static <T> ResponseEntity<Map<String, Object>> of(SuccessCode code, T data,
+        URI createdLocation) {
+        return switch (code.getStatus()) {
+            case OK -> ResponseEntity.ok(
+                buildBody(code.getCode(), code.getStatus().name(), code.getMessage(), data));
+            case CREATED -> ResponseEntity.created(createdLocation)
+                .body(buildBody(code.getCode(), code.getStatus().name(), code.getMessage(), data));
+            case NO_CONTENT -> ResponseEntity.noContent().build();
+        };
+    }
+
+    private static <T> Map<String, Object> buildBody(String code, String status, String message,
+        T data) {
+        return Map.of(
+            "code", code,
+            "status", status,
+            "message", message,
+            "data", data
+        );
+    }
+
+}

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessCode.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessCode.java
@@ -1,0 +1,21 @@
+package io.twogether.nbe_5_7_2_02team.global.response.success;
+
+import static io.twogether.nbe_5_7_2_02team.global.response.success.SuccessStatus.CREATED;
+import static io.twogether.nbe_5_7_2_02team.global.response.success.SuccessStatus.OK;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    FOUND_MEMBER(OK, "MEMBER-200", "Found member"),
+    CREATE_MEMBER(CREATED, "MEMBER-201", "Create member"),
+
+    FOUND_FOLLOWER(OK, "FOLLOWER-200", "Found follower"),
+    CREATE_FOLLOWER(CREATED, "FOLLOWER-201", "Create follower");
+
+    private final SuccessStatus status;
+    private final String code;
+    private final String message;
+}

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessCode.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessCode.java
@@ -2,13 +2,13 @@ package io.twogether.nbe_5_7_2_02team.global.response.success;
 
 import static io.twogether.nbe_5_7_2_02team.global.response.success.SuccessStatus.CREATED;
 import static io.twogether.nbe_5_7_2_02team.global.response.success.SuccessStatus.OK;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum SuccessCode {
-
     FOUND_MEMBER(OK, "MEMBER-200", "Found member"),
     CREATE_MEMBER(CREATED, "MEMBER-201", "Create member"),
 

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessStatus.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/SuccessStatus.java
@@ -1,0 +1,7 @@
+package io.twogether.nbe_5_7_2_02team.global.response.success;
+
+public enum SuccessStatus {
+    OK,
+    CREATED,
+    NO_CONTENT
+}


### PR DESCRIPTION
## 관련 이슈

<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

close #19 

## 개요

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

RestController의 기본 응답을 위한 구조를 생성했습니다.
아래의 항목을 포함합니다.
- status
- code
- message
- body

응답 구조 사용 시, 아래와 같이 사용할 수 있습니다.
```
public ResponseEntity<?> getTag() {
    return BaseResponse.of(SuccessCode.CREATE_TAG, tag, URI.create("/api/tags/1"));
}
```