### PR TITLE
fix: BaseResponse 리팩터링 및 FollowService의 import 오류 수정

### DIFF
--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
@@ -1,23 +1,28 @@
 package io.twogether.nbe_5_7_2_02team.global.response.success;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
 import java.util.Map;
 
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class BaseResponse<T> {
 
-    private int code;
-    private String status;
-    private String message;
-    private T data;
+    private final String code;
+    private final String status;
+    private final String message;
+    private final T data;
 
-    public static <T> ResponseEntity<Map<String, Object>> of(
+    public static <T> ResponseEntity<BaseResponse<T>> of(
             SuccessCode code, T data, URI createdLocation) {
         return switch (code.getStatus()) {
             case OK ->
                     ResponseEntity.ok(
-                            buildBody(
+                            new BaseResponse<>(
                                     code.getCode(),
                                     code.getStatus().name(),
                                     code.getMessage(),
@@ -25,21 +30,12 @@ public class BaseResponse<T> {
             case CREATED ->
                     ResponseEntity.created(createdLocation)
                             .body(
-                                    buildBody(
+                                new BaseResponse<>(
                                             code.getCode(),
                                             code.getStatus().name(),
                                             code.getMessage(),
                                             data));
             case NO_CONTENT -> ResponseEntity.noContent().build();
         };
-    }
-
-    private static <T> Map<String, Object> buildBody(
-            String code, String status, String message, T data) {
-        return Map.of(
-                "code", code,
-                "status", status,
-                "message", message,
-                "data", data);
     }
 }

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/global/response/success/BaseResponse.java
@@ -3,10 +3,10 @@ package io.twogether.nbe_5_7_2_02team.global.response.success;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
-import java.util.Map;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -30,7 +30,7 @@ public class BaseResponse<T> {
             case CREATED ->
                     ResponseEntity.created(createdLocation)
                             .body(
-                                new BaseResponse<>(
+                                    new BaseResponse<>(
                                             code.getCode(),
                                             code.getStatus().name(),
                                             code.getMessage(),

--- a/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/member/service/FollowService.java
+++ b/NBE_5_7_2_02TEAM/src/main/java/io/twogether/nbe_5_7_2_02team/member/service/FollowService.java
@@ -1,10 +1,10 @@
 package io.twogether.nbe_5_7_2_02team.member.service;
 
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorCode.NOT_DUPLICATION_FOLLOW;
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorCode.NOT_FOUND_FOLLOWER;
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorCode.NOT_FOUND_FOLLOWING;
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorCode.NOT_FOUND_MEMBER;
-import static io.twogether.nbe_5_7_2_02team.global.exception.ErrorCode.NOT_YOURSELF_FOLLOW;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_DUPLICATION_FOLLOW;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_FOUND_FOLLOWER;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_FOUND_FOLLOWING;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_FOUND_MEMBER;
+import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_YOURSELF_FOLLOW;
 
 import io.twogether.nbe_5_7_2_02team.global.exception.ErrorException;
 import io.twogether.nbe_5_7_2_02team.member.dao.FollowRepository;


### PR DESCRIPTION
## 관련 이슈

<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

fix #21 

## 개요

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

- #20 PR에서 패키지 리팩터링에 따른 FollowService의 import 변경 사항을 git에 추가하지 않아 이를 추가함
- BaseResponse의 필드를 사용하지 않고, Map을 반환해 body를 생성하는 불필요 로직을 리팩터링함