### PR TITLE
refactor: BrowserTest에 DBRider 적용

### DIFF
--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
@@ -1,28 +1,25 @@
 package io.twogether.nbe_5_7_2_02team.browser;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
+import io.twogether.nbe_5_7_2_02team.oauth.dto.common.TokenPair;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.DONE;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.NONE;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.RECRUITING;
 
+import lombok.extern.slf4j.Slf4j;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.twogether.nbe_5_7_2_02team.browser.template.BrowserTestTemplate;
-import io.twogether.nbe_5_7_2_02team.global.common.BaseEntity;
-import io.twogether.nbe_5_7_2_02team.member.dao.FollowRepository;
 import io.twogether.nbe_5_7_2_02team.member.dao.MemberRepository;
-import io.twogether.nbe_5_7_2_02team.member.domain.Follow;
 import io.twogether.nbe_5_7_2_02team.member.domain.Member;
-import io.twogether.nbe_5_7_2_02team.post.dao.PostRepository;
-import io.twogether.nbe_5_7_2_02team.post.domain.Post;
 import io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus;
 
 import lombok.AllArgsConstructor;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,20 +27,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
-import java.lang.reflect.Field;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
+@Slf4j
+@FlywayReset
 public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
-    @Autowired PostRepository postRepository;
-    @Autowired MemberRepository memberRepository;
-    @Autowired FollowRepository followRepository;
-
-    Random random = new Random();
+    @Autowired
+    MemberRepository memberRepository;
 
     @AllArgsConstructor
     static class PostCreateRequest {
@@ -53,22 +47,11 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
         private RecruitmentStatus recruitmentStatus;
     }
 
-    @BeforeEach
-    public void setup() {
-        // Dummy Post 생성
-        for (int i = 0; i < random.nextInt(90) + 10; i++) {
-            postRepository.save(
-                    Post.builder()
-                            .title("TITLE-" + i)
-                            .content("CONTENT-" + i)
-                            .member(member)
-                            .recruitmentStatus(NONE)
-                            .build());
-        }
-    }
-
     @ParameterizedTest
     @MethodSource("postRequestProvider")
+    @DataSet(value = "datasets/v2/member.yml",
+        cleanBefore = true
+    )
     @DisplayName("POST: /api/posts 게시글 생성")
     void createPost(PostCreateRequest request) throws Exception {
         createPostHelper(request);
@@ -76,202 +59,213 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     static Stream<PostCreateRequest> postRequestProvider() {
         return Stream.of(
-                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), NONE),
-                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), DONE),
-                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG", "TAG-2"), RECRUITING));
+            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), NONE),
+            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), DONE),
+            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG", "TAG-2"), RECRUITING));
     }
 
     void createPostHelper(PostCreateRequest request) throws Exception {
+        // given
+        TokenPair tokenPair = getTokenPair(1L);
+
         // when & then
         mockMvc.perform(
-                        multipart("/api/posts")
-                                .param("title", request.title)
-                                .param("content", request.content)
-                                .param("tags", request.tags.toArray(new String[0]))
-                                .param("recruitmentStatus", request.recruitmentStatus.toString())
-                                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
-                .andExpect(status().isCreated());
+            multipart("/api/posts")
+                .param("title", request.title)
+                .param("content", request.content)
+                .param("tags", request.tags.toArray(new String[0]))
+                .param("recruitmentStatus", request.recruitmentStatus.toString())
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
+        ).andExpect(status().isCreated());
     }
 
     @Test
+    @DataSet(
+        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+        cleanBefore = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 필터 없음")
     void getPosts() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/posts").param("limit", "10"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(10));
+        mockMvc.perform(get("/api/posts").param("limit", "10")
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(4)
+        );
     }
 
     @Test
+    @DataSet(
+        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+        cleanBefore = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 모집 여부 필터링")
     void getPostsWithRecruitStatus() throws Exception {
-        // given
-        PostCreateRequest request =
-                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), RECRUITING);
-        createPostHelper(request);
-
         // when & then
-        mockMvc.perform(get("/api/posts").param("limit", "10").param("isRecruit", "true"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(1))
-                .andExpect(jsonPath("$.posts[0].recruitment_status").value(RECRUITING.toString()));
+        mockMvc.perform(get("/api/posts")
+            .param("limit", "10")
+            .param("isRecruit", "true")
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(2),
+            jsonPath("$.posts[0].recruitment_status").value(RECRUITING.toString())
+        );
     }
 
     @Test
+    @DataSet(
+        value = {
+            "datasets/v2/member.yml",
+            "datasets/v2/post.yml",
+            "datasets/v2/tag.yml",
+        }, cleanBefore = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 태그 필터링")
     void getPostsWithTag() throws Exception {
         // given
-        String targetTag = "TAG";
-        PostCreateRequest request =
-                new PostCreateRequest("TITLE", "CONTENT", List.of(targetTag), RECRUITING);
-        createPostHelper(request);
+        String targetTag = "TAG-1";
 
         // when & then
         mockMvc.perform(
-                        get("/api/posts")
-                                .param("limit", "10")
-                                .param("tags", targetTag)
-                                .param("isRecruit", "true"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(1))
-                .andExpect(jsonPath("$.posts[0].tags[0]").value(targetTag));
+            get("/api/posts")
+                .param("limit", "10")
+                .param("tags", targetTag)
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(2)
+        );
     }
 
     @Test
+    @DataSet(
+        value = {
+            "datasets/v2/member.yml",
+            "datasets/v2/post.yml",
+            "datasets/v2/tag.yml",
+        }, cleanBefore = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 여러 개 태그 필터링")
     void getPostsWithTags() throws Exception {
         // given
-        String[] targetTags = {"TEST_TAG_1", "TEST_TAG_2"};
-        PostCreateRequest targetRequest =
-                new PostCreateRequest(
-                        "TARGET_TITLE", "TARGET_CONTENT", List.of(targetTags), RECRUITING);
-        PostCreateRequest fakeRequest =
-                new PostCreateRequest(
-                        "FAKE_TITLE", "FAKE_CONTENT", List.of(targetTags[0]), RECRUITING);
-        createPostHelper(targetRequest);
-        createPostHelper(fakeRequest);
+        String[] targetTags = {"TAG-1", "TAG-2"};
 
         // when & then
         mockMvc.perform(
-                        get("/api/posts")
-                                .param("limit", "10")
-                                .param("tags", targetTags)
-                                .param("isRecruit", "true"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(1))
-                .andExpect(jsonPath("$.posts[0].tags.length()").value(2))
-                .andExpect(jsonPath("$.posts[0].tags[0]").value(targetTags[0]))
-                .andExpect(jsonPath("$.posts[0].tags[1]").value(targetTags[1]));
+            get("/api/posts")
+                .param("limit", "10")
+                .param("tags", targetTags)
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(1),
+            jsonPath("$.posts[0].tags.length()").value(2),
+            jsonPath("$.posts[0].tags").value(containsInAnyOrder(targetTags))
+        );
     }
 
     @Test
+    @DataSet(
+        value = {
+            "datasets/v2/member.yml",
+            "datasets/v2/post.yml",
+            "datasets/v2/follow.yml"
+        }, cleanBefore = true
+    )
     @DisplayName("GET: /api/posts 회원 접근 - 팔로잉 필터링")
     void getPostsWithFollowing() throws Exception {
         // given
-        Member followingMember = createAndSaveMockMember();
-        followRepository.save(new Follow(member, followingMember));
-        createAndSaveMockPosts(followingMember, 5);
+        // member1이 member2를 팔로우
+        long followerId = 1L;
+        long targetMemberId = 2L;
+        TokenPair tokenPair = getTokenPair(followerId);
 
         // when & then
         mockMvc.perform(
-                        get("/api/posts")
-                                .param("limit", "10")
-                                .param("isFollowing", "true")
-                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(5))
-                .andExpect(jsonPath("$.posts[0].member_id").value(followingMember.getId()));
+            get("/api/posts")
+                .param("limit", "10")
+                .param("isFollowing", "true")
+                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(1),
+            jsonPath("$.posts[0].member_id").value(targetMemberId)
+        );
+
+
     }
 
     @Test
+    @DataSet(
+        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+        cleanBefore = true
+    )
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 특정 멤버 작성 게시글 조회")
     void getPostsWithMemberId() throws Exception {
         // given
-        Member targetMember = createAndSaveMockMember();
-        createAndSaveMockPosts(targetMember, 5);
+        long targetMemberId = 1;
+        TokenPair tokenPair = getTokenPair(targetMemberId);
 
         // when & then
         mockMvc.perform(
-                        get("/api/posts/member/" + targetMember.getId())
-                                .param("limit", "10")
-                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(5))
-                .andExpect(jsonPath("$.posts[0].member_id").value(targetMember.getId()));
+            get("/api/posts/member/" + targetMemberId)
+                .param("limit", "10")
+                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(3),
+            jsonPath("$.posts[0].member_id").value(targetMemberId)
+        );
+
+
     }
 
     @Test
+    @DataSet(
+        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+        cleanBefore = true
+    )
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 페이징 테스트")
     void getPostsPaging() throws Exception {
         // given
-        Member targetMember = createAndSaveMockMember();
-        List<Post> posts = createAndSaveMockPosts(targetMember, 10);
-
-        Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
-        createdAtField.setAccessible(true);
-        LocalDateTime createdAt = LocalDateTime.now();
-        for (Post post : posts) {
-            createdAtField.set(post, createdAt);
-            createdAt = createdAt.plusDays(1);
-        }
+        long targetMemberId = 1;
+        TokenPair tokenPair = getTokenPair(targetMemberId);
 
         // when & then
         /*
          * [최신 Post 조회 검증]
          * posts 리스트는 index 순으로 오래된 항목부터 최신 항목까지 저장되어 있음.
-         * 이에 따라 posts.getLast()는 가장 최신 항목을 반환함.
-         * 따라서 "limit=1"을 통해 조회할 경우, 가장 최신 항목인 post.getLast()를 반환해야 함.
+         * 따라서 "limit=1"을 통해 조회할 경우, 가장 최신 post 반환해야 함.
          */
         mockMvc.perform(
-                        get("/api/posts/member/" + targetMember.getId())
-                                .param("limit", "1")
-                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(1))
-                .andExpect(jsonPath("$.posts[0].member_id").value(targetMember.getId()))
-                .andExpect(jsonPath("$.posts[0].post_id").value(posts.getLast().getId()));
+            get("/api/posts/member/" + targetMemberId)
+                .param("limit", "1")
+                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(1),
+            jsonPath("$.posts[0].member_id").value(targetMemberId),
+            jsonPath("$.posts[0].post_id").value(3)
+        );
 
         /*
          * [Offset 조회 검증]
-         * "lastPostId"에 해당하는 Post 이후로 가장 최신의 post 항목들을 조회.
-         * 아래 시험에서는 lastPostId가 posts.get(5)의 id를 나타내고 있음.
-         * 따라서 "limit=1"을 통해 조회할 경우, posts.get(4)를 반환해야 함.
+         * "lastPostId"에 해당하는 Post 이후로 가장 최신의 post를 조회.
          */
         mockMvc.perform(
-                        get("/api/posts/member/" + targetMember.getId())
-                                .param("limit", "1")
-                                .param("lastPostId", posts.get(5).getId().toString())
-                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.posts.length()").value(1))
-                .andExpect(jsonPath("$.posts[0].member_id").value(targetMember.getId()))
-                .andExpect(jsonPath("$.posts[0].post_id").value(posts.get(4).getId()));
+            get("/api/posts/member/" + targetMemberId)
+                .param("limit", "1")
+                .param("lastPostId", "2")
+                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
+        ).andExpectAll(
+            status().isOk(),
+            jsonPath("$.posts.length()").value(1),
+            jsonPath("$.posts[0].member_id").value(targetMemberId),
+            jsonPath("$.posts[0].post_id").value(1)
+        );
     }
 
-    private List<Post> createAndSaveMockPosts(Member member, int numPosts) {
-        List<Post> posts = new ArrayList<>();
-        for (int i = 0; i < numPosts; i++) {
-            Post post =
-                    Post.builder()
-                            .title("TARGET_TITLE-" + i)
-                            .content("TARGET_CONTENT-" + i)
-                            .member(member)
-                            .recruitmentStatus(NONE)
-                            .build();
-            postRepository.save(post);
-            posts.add(post);
-        }
-        return posts;
-    }
-
-    private Member createAndSaveMockMember() {
-        Member targetMember =
-                Member.builder()
-                        .name("TARGET_MEMBER")
-                        .email("TARGET_MEMBER@example.com")
-                        .githubId("github.com")
-                        .build();
-        return memberRepository.save(targetMember);
+    private TokenPair getTokenPair(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        return jwtTokenProvider.generateTokenPair(member);
     }
 }

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
@@ -20,7 +20,6 @@ import io.twogether.nbe_5_7_2_02team.oauth.dto.common.TokenPair;
 import io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus;
 
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +31,6 @@ import org.springframework.http.MediaType;
 import java.util.List;
 import java.util.stream.Stream;
 
-@Slf4j
 @FlywayReset
 public class PostBrowserSuccessTest extends BrowserTestTemplate {
 

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
@@ -46,10 +46,7 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     @ParameterizedTest
     @MethodSource("postRequestProvider")
-    @DataSet(
-        value = "datasets/v2/member.yml",
-        cleanBefore = true, cleanAfter = true
-    )
+    @DataSet(value = "datasets/v2/member.yml", cleanBefore = true, cleanAfter = true)
     @DisplayName("POST: /api/posts 게시글 생성")
     void createPost(PostCreateRequest request) throws Exception {
         createPostHelper(request);
@@ -80,9 +77,9 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     @Test
     @DataSet(
-        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true, cleanAfter = true
-    )
+            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 필터 없음")
     void getPosts() throws Exception {
         // when & then
@@ -93,8 +90,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-            cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 모집 여부 필터링")
     void getPostsWithRecruitStatus() throws Exception {
         // when & then
@@ -112,8 +109,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
             },
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 태그 필터링")
     void getPostsWithTag() throws Exception {
         // given
@@ -131,8 +128,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
             },
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 여러 개 태그 필터링")
     void getPostsWithTags() throws Exception {
         // given
@@ -150,8 +147,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml", "datasets/v2/post.yml", "datasets/v2/follow.yml"},
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts 회원 접근 - 팔로잉 필터링")
     void getPostsWithFollowing() throws Exception {
         // given
@@ -175,8 +172,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 특정 멤버 작성 게시글 조회")
     void getPostsWithMemberId() throws Exception {
         // given
@@ -197,8 +194,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 페이징 테스트")
     void getPostsPaging() throws Exception {
         // given

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
@@ -1,24 +1,26 @@
 package io.twogether.nbe_5_7_2_02team.browser;
 
-import com.github.database.rider.core.api.dataset.DataSet;
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
-import io.twogether.nbe_5_7_2_02team.oauth.dto.common.TokenPair;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.DONE;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.NONE;
 import static io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus.RECRUITING;
 
-import lombok.extern.slf4j.Slf4j;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+
 import io.twogether.nbe_5_7_2_02team.browser.template.BrowserTestTemplate;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.member.dao.MemberRepository;
 import io.twogether.nbe_5_7_2_02team.member.domain.Member;
+import io.twogether.nbe_5_7_2_02team.oauth.dto.common.TokenPair;
 import io.twogether.nbe_5_7_2_02team.post.domain.RecruitmentStatus;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +29,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -36,8 +36,7 @@ import java.util.stream.Stream;
 @FlywayReset
 public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
-    @Autowired
-    MemberRepository memberRepository;
+    @Autowired MemberRepository memberRepository;
 
     @AllArgsConstructor
     static class PostCreateRequest {
@@ -49,9 +48,7 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     @ParameterizedTest
     @MethodSource("postRequestProvider")
-    @DataSet(value = "datasets/v2/member.yml",
-        cleanBefore = true
-    )
+    @DataSet(value = "datasets/v2/member.yml", cleanBefore = true)
     @DisplayName("POST: /api/posts 게시글 생성")
     void createPost(PostCreateRequest request) throws Exception {
         createPostHelper(request);
@@ -59,9 +56,9 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     static Stream<PostCreateRequest> postRequestProvider() {
         return Stream.of(
-            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), NONE),
-            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), DONE),
-            new PostCreateRequest("TITLE", "CONTENT", List.of("TAG", "TAG-2"), RECRUITING));
+                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), NONE),
+                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG"), DONE),
+                new PostCreateRequest("TITLE", "CONTENT", List.of("TAG", "TAG-2"), RECRUITING));
     }
 
     void createPostHelper(PostCreateRequest request) throws Exception {
@@ -70,107 +67,85 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
         // when & then
         mockMvc.perform(
-            multipart("/api/posts")
-                .param("title", request.title)
-                .param("content", request.content)
-                .param("tags", request.tags.toArray(new String[0]))
-                .param("recruitmentStatus", request.recruitmentStatus.toString())
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
-        ).andExpect(status().isCreated());
+                        multipart("/api/posts")
+                                .param("title", request.title)
+                                .param("content", request.content)
+                                .param("tags", request.tags.toArray(new String[0]))
+                                .param("recruitmentStatus", request.recruitmentStatus.toString())
+                                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
+                .andExpect(status().isCreated());
     }
 
     @Test
     @DataSet(
-        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true
-    )
+            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+            cleanBefore = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 필터 없음")
     void getPosts() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/posts").param("limit", "10")
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(4)
-        );
+        mockMvc.perform(get("/api/posts").param("limit", "10"))
+                .andExpectAll(status().isOk(), jsonPath("$.posts.length()").value(4));
     }
 
     @Test
     @DataSet(
-        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true
-    )
+            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+            cleanBefore = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 모집 여부 필터링")
     void getPostsWithRecruitStatus() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/posts")
-            .param("limit", "10")
-            .param("isRecruit", "true")
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(2),
-            jsonPath("$.posts[0].recruitment_status").value(RECRUITING.toString())
-        );
+        mockMvc.perform(get("/api/posts").param("limit", "10").param("isRecruit", "true"))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(2),
+                        jsonPath("$.posts[0].recruitment_status").value(RECRUITING.toString()));
     }
 
     @Test
     @DataSet(
-        value = {
-            "datasets/v2/member.yml",
-            "datasets/v2/post.yml",
-            "datasets/v2/tag.yml",
-        }, cleanBefore = true
-    )
+            value = {
+                "datasets/v2/member.yml",
+                "datasets/v2/post.yml",
+                "datasets/v2/tag.yml",
+            },
+            cleanBefore = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 태그 필터링")
     void getPostsWithTag() throws Exception {
         // given
         String targetTag = "TAG-1";
 
         // when & then
-        mockMvc.perform(
-            get("/api/posts")
-                .param("limit", "10")
-                .param("tags", targetTag)
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(2)
-        );
+        mockMvc.perform(get("/api/posts").param("limit", "10").param("tags", targetTag))
+                .andExpectAll(status().isOk(), jsonPath("$.posts.length()").value(2));
     }
 
     @Test
     @DataSet(
-        value = {
-            "datasets/v2/member.yml",
-            "datasets/v2/post.yml",
-            "datasets/v2/tag.yml",
-        }, cleanBefore = true
-    )
+            value = {
+                "datasets/v2/member.yml",
+                "datasets/v2/post.yml",
+                "datasets/v2/tag.yml",
+            },
+            cleanBefore = true)
     @DisplayName("GET: /api/posts 비회원 접근 - 여러 개 태그 필터링")
     void getPostsWithTags() throws Exception {
         // given
         String[] targetTags = {"TAG-1", "TAG-2"};
 
         // when & then
-        mockMvc.perform(
-            get("/api/posts")
-                .param("limit", "10")
-                .param("tags", targetTags)
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(1),
-            jsonPath("$.posts[0].tags.length()").value(2),
-            jsonPath("$.posts[0].tags").value(containsInAnyOrder(targetTags))
-        );
+        mockMvc.perform(get("/api/posts").param("limit", "10").param("tags", targetTags))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(1),
+                        jsonPath("$.posts[0].tags.length()").value(2),
+                        jsonPath("$.posts[0].tags").value(containsInAnyOrder(targetTags)));
     }
 
     @Test
     @DataSet(
-        value = {
-            "datasets/v2/member.yml",
-            "datasets/v2/post.yml",
-            "datasets/v2/follow.yml"
-        }, cleanBefore = true
-    )
+            value = {"datasets/v2/member.yml", "datasets/v2/post.yml", "datasets/v2/follow.yml"},
+            cleanBefore = true)
     @DisplayName("GET: /api/posts 회원 접근 - 팔로잉 필터링")
     void getPostsWithFollowing() throws Exception {
         // given
@@ -181,24 +156,20 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
         // when & then
         mockMvc.perform(
-            get("/api/posts")
-                .param("limit", "10")
-                .param("isFollowing", "true")
-                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(1),
-            jsonPath("$.posts[0].member_id").value(targetMemberId)
-        );
-
-
+                        get("/api/posts")
+                                .param("limit", "10")
+                                .param("isFollowing", "true")
+                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(1),
+                        jsonPath("$.posts[0].member_id").value(targetMemberId));
     }
 
     @Test
     @DataSet(
-        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true
-    )
+            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+            cleanBefore = true)
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 특정 멤버 작성 게시글 조회")
     void getPostsWithMemberId() throws Exception {
         // given
@@ -207,23 +178,19 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
         // when & then
         mockMvc.perform(
-            get("/api/posts/member/" + targetMemberId)
-                .param("limit", "10")
-                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(3),
-            jsonPath("$.posts[0].member_id").value(targetMemberId)
-        );
-
-
+                        get("/api/posts/member/" + targetMemberId)
+                                .param("limit", "10")
+                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(3),
+                        jsonPath("$.posts[0].member_id").value(targetMemberId));
     }
 
     @Test
     @DataSet(
-        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-        cleanBefore = true
-    )
+            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+            cleanBefore = true)
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 페이징 테스트")
     void getPostsPaging() throws Exception {
         // given
@@ -237,31 +204,29 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
          * 따라서 "limit=1"을 통해 조회할 경우, 가장 최신 post 반환해야 함.
          */
         mockMvc.perform(
-            get("/api/posts/member/" + targetMemberId)
-                .param("limit", "1")
-                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(1),
-            jsonPath("$.posts[0].member_id").value(targetMemberId),
-            jsonPath("$.posts[0].post_id").value(3)
-        );
+                        get("/api/posts/member/" + targetMemberId)
+                                .param("limit", "1")
+                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(1),
+                        jsonPath("$.posts[0].member_id").value(targetMemberId),
+                        jsonPath("$.posts[0].post_id").value(3));
 
         /*
          * [Offset 조회 검증]
          * "lastPostId"에 해당하는 Post 이후로 가장 최신의 post를 조회.
          */
         mockMvc.perform(
-            get("/api/posts/member/" + targetMemberId)
-                .param("limit", "1")
-                .param("lastPostId", "2")
-                .header("Authorization", "Bearer " + tokenPair.getAccessToken())
-        ).andExpectAll(
-            status().isOk(),
-            jsonPath("$.posts.length()").value(1),
-            jsonPath("$.posts[0].member_id").value(targetMemberId),
-            jsonPath("$.posts[0].post_id").value(1)
-        );
+                        get("/api/posts/member/" + targetMemberId)
+                                .param("limit", "1")
+                                .param("lastPostId", "2")
+                                .header("Authorization", "Bearer " + tokenPair.getAccessToken()))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts.length()").value(1),
+                        jsonPath("$.posts[0].member_id").value(targetMemberId),
+                        jsonPath("$.posts[0].post_id").value(1));
     }
 
     private TokenPair getTokenPair(Long memberId) {

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/PostBrowserSuccessTest.java
@@ -46,7 +46,10 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     @ParameterizedTest
     @MethodSource("postRequestProvider")
-    @DataSet(value = "datasets/v2/member.yml", cleanBefore = true)
+    @DataSet(
+        value = "datasets/v2/member.yml",
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("POST: /api/posts 게시글 생성")
     void createPost(PostCreateRequest request) throws Exception {
         createPostHelper(request);
@@ -77,8 +80,9 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
 
     @Test
     @DataSet(
-            value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-            cleanBefore = true)
+        value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 필터 없음")
     void getPosts() throws Exception {
         // when & then
@@ -89,7 +93,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-            cleanBefore = true)
+            cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 모집 여부 필터링")
     void getPostsWithRecruitStatus() throws Exception {
         // when & then
@@ -107,7 +112,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
             },
-            cleanBefore = true)
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 태그 필터링")
     void getPostsWithTag() throws Exception {
         // given
@@ -125,7 +131,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
             },
-            cleanBefore = true)
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts 비회원 접근 - 여러 개 태그 필터링")
     void getPostsWithTags() throws Exception {
         // given
@@ -143,7 +150,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml", "datasets/v2/post.yml", "datasets/v2/follow.yml"},
-            cleanBefore = true)
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts 회원 접근 - 팔로잉 필터링")
     void getPostsWithFollowing() throws Exception {
         // given
@@ -167,7 +175,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-            cleanBefore = true)
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 특정 멤버 작성 게시글 조회")
     void getPostsWithMemberId() throws Exception {
         // given
@@ -188,7 +197,8 @@ public class PostBrowserSuccessTest extends BrowserTestTemplate {
     @Test
     @DataSet(
             value = {"datasets/v2/member.yml, datasets/v2/post.yml"},
-            cleanBefore = true)
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/posts/member/{memberId} 회원 접근 - 페이징 테스트")
     void getPostsPaging() throws Exception {
         // given

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
@@ -23,7 +23,9 @@ public class TagBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/member.yml",
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
-            })
+            },
+        cleanBefore = true, cleanAfter = true
+    )
     @DisplayName("GET: /api/tags - 모든 태그 반환")
     void getAllTags() throws Exception {
         // given

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
@@ -1,5 +1,7 @@
 package io.twogether.nbe_5_7_2_02team.browser;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -7,33 +9,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.twogether.nbe_5_7_2_02team.browser.template.BrowserTestTemplate;
-import io.twogether.nbe_5_7_2_02team.tag.dao.TagRepository;
-import io.twogether.nbe_5_7_2_02team.tag.domain.Tag;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
+@FlywayReset
 public class TagBrowserSuccessTest extends BrowserTestTemplate {
 
-    @Autowired TagRepository tagRepository;
-
-    private final Random random = new Random();
-
     @Test
+    @DataSet(
+        value = {
+            "datasets/v2/member.yml",
+            "datasets/v2/post.yml",
+            "datasets/v2/tag.yml",
+        }
+    )
     @DisplayName("GET: /api/tags - 모든 태그 반환")
     void getAllTags() throws Exception {
         // given
-        List<String> tagNames = new ArrayList<>();
-        for (int i = 0; i < random.nextInt(10) + 1; i++) {
-            String tagName = "TAG-" + i;
-            tagRepository.save(new Tag(tagName));
-            tagNames.add(tagName);
-        }
+        String[] tagNames = {"TAG-1", "TAG-2"};
 
         // when & then
         mockMvc.perform(get("/api/tags"))
@@ -41,7 +35,7 @@ public class TagBrowserSuccessTest extends BrowserTestTemplate {
                 .andExpect(status().isOk())
                 .andExpect(
                         jsonPath("$.tags")
-                                .value(containsInAnyOrder(tagNames.toArray(new String[0]))));
+                                .value(containsInAnyOrder(tagNames)));
     }
 
     @Test

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
@@ -24,8 +24,8 @@ public class TagBrowserSuccessTest extends BrowserTestTemplate {
                 "datasets/v2/post.yml",
                 "datasets/v2/tag.yml",
             },
-        cleanBefore = true, cleanAfter = true
-    )
+            cleanBefore = true,
+            cleanAfter = true)
     @DisplayName("GET: /api/tags - 모든 태그 반환")
     void getAllTags() throws Exception {
         // given

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/TagBrowserSuccessTest.java
@@ -1,14 +1,15 @@
 package io.twogether.nbe_5_7_2_02team.browser;
 
-import com.github.database.rider.core.api.dataset.DataSet;
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+
 import io.twogether.nbe_5_7_2_02team.browser.template.BrowserTestTemplate;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,12 +19,11 @@ public class TagBrowserSuccessTest extends BrowserTestTemplate {
 
     @Test
     @DataSet(
-        value = {
-            "datasets/v2/member.yml",
-            "datasets/v2/post.yml",
-            "datasets/v2/tag.yml",
-        }
-    )
+            value = {
+                "datasets/v2/member.yml",
+                "datasets/v2/post.yml",
+                "datasets/v2/tag.yml",
+            })
     @DisplayName("GET: /api/tags - 모든 태그 반환")
     void getAllTags() throws Exception {
         // given
@@ -33,9 +33,7 @@ public class TagBrowserSuccessTest extends BrowserTestTemplate {
         mockMvc.perform(get("/api/tags"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(
-                        jsonPath("$.tags")
-                                .value(containsInAnyOrder(tagNames)));
+                .andExpect(jsonPath("$.tags").value(containsInAnyOrder(tagNames)));
     }
 
     @Test

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
@@ -2,46 +2,28 @@ package io.twogether.nbe_5_7_2_02team.browser.template;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
 import io.twogether.nbe_5_7_2_02team.browser.config.MockTestConfig;
-import io.twogether.nbe_5_7_2_02team.member.dao.MemberRepository;
-import io.twogether.nbe_5_7_2_02team.member.domain.Member;
-import io.twogether.nbe_5_7_2_02team.member.domain.Role;
-import io.twogether.nbe_5_7_2_02team.oauth.dto.common.TokenPair;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.oauth.jwt.JwtTokenProvider;
 
-import org.junit.jupiter.api.BeforeEach;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
+@DBRider
+@FlywayReset
+@DataSet(cleanBefore = true, cleanAfter = true)
 @SpringBootTest
 @AutoConfigureMockMvc
 @Import(MockTestConfig.class)
 public abstract class BrowserTestTemplate {
 
-    @Autowired public ObjectMapper objectMapper;
     @Autowired public MockMvc mockMvc;
-    @Autowired public MemberRepository memberRepository;
     @Autowired public JwtTokenProvider jwtTokenProvider;
 
-    public Member member;
-    public TokenPair tokenPair;
-
-    @BeforeEach
-    public void memberSetup() {
-        memberRepository.save(
-                member =
-                        Member.builder()
-                                .name("TEST_MEMBER")
-                                .email("TEST_MEMBER@example.com")
-                                .githubId("github.com")
-                                .profileImage("TEST_IMAGE")
-                                .role(Role.MEMBER)
-                                .build());
-        tokenPair = jwtTokenProvider.generateTokenPair(member);
-    }
 }

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
@@ -1,13 +1,12 @@
 package io.twogether.nbe_5_7_2_02team.browser.template;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
+
 import io.twogether.nbe_5_7_2_02team.browser.config.MockTestConfig;
 import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.oauth.jwt.JwtTokenProvider;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -25,5 +24,4 @@ public abstract class BrowserTestTemplate {
 
     @Autowired public MockMvc mockMvc;
     @Autowired public JwtTokenProvider jwtTokenProvider;
-
 }

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
@@ -1,6 +1,5 @@
 package io.twogether.nbe_5_7_2_02team.browser.template;
 
-import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
 
 import io.twogether.nbe_5_7_2_02team.browser.config.MockTestConfig;
@@ -15,7 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @DBRider
 @FlywayReset
-@DataSet(cleanBefore = true, cleanAfter = true)
 @SpringBootTest
 @AutoConfigureMockMvc
 @Import(MockTestConfig.class)

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/browser/template/BrowserTestTemplate.java
@@ -1,6 +1,5 @@
 package io.twogether.nbe_5_7_2_02team.browser.template;
 
-
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
 

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatMemberServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatMemberServiceTest.java
@@ -1,8 +1,6 @@
 package io.twogether.nbe_5_7_2_02team.chat.service;
 
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.*;
-
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,6 +12,7 @@ import io.twogether.nbe_5_7_2_02team.chat.domain.ChatMemberStatus;
 import io.twogether.nbe_5_7_2_02team.chat.domain.ChatRoom;
 import io.twogether.nbe_5_7_2_02team.chat.dto.response.ChatMemberGetResponse;
 import io.twogether.nbe_5_7_2_02team.chat.util.CheckUserLogin;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.global.exception.ErrorException;
 import io.twogether.nbe_5_7_2_02team.member.dao.MemberRepository;
 import io.twogether.nbe_5_7_2_02team.member.domain.Member;

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatMemberServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatMemberServiceTest.java
@@ -1,6 +1,8 @@
 package io.twogether.nbe_5_7_2_02team.chat.service;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.*;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 
+@FlywayReset
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatRoomServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatRoomServiceTest.java
@@ -1,9 +1,7 @@
 package io.twogether.nbe_5_7_2_02team.chat.service;
 
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.CHAT_ROOM_ALREADY_EXISTS;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_FOUND_POST;
-
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.twogether.nbe_5_7_2_02team.chat.dao.ChatRoomRepository;
 import io.twogether.nbe_5_7_2_02team.chat.domain.ChatRoom;
 import io.twogether.nbe_5_7_2_02team.chat.dto.response.ChatRoomGetResponse;
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.global.exception.ErrorException;
 import io.twogether.nbe_5_7_2_02team.post.dao.PostRepository;
 import io.twogether.nbe_5_7_2_02team.post.domain.Post;

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatRoomServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/chat/service/ChatRoomServiceTest.java
@@ -1,7 +1,9 @@
 package io.twogether.nbe_5_7_2_02team.chat.service;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.CHAT_ROOM_ALREADY_EXISTS;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_FOUND_POST;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+@FlywayReset
 @Transactional
 @SpringBootTest
 class ChatRoomServiceTest {

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/db/template/MigrationTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/db/template/MigrationTestTemplate.java
@@ -5,11 +5,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.sql.DataSource;
+import org.springframework.test.context.event.annotation.AfterTestClass;
 
 @SpringBootTest
 public abstract class MigrationTestTemplate {
 
-    @Autowired protected DataSource dataSource;
+    @Autowired private DataSource dataSource;
+    @Autowired private Flyway flyway;
+
+    @AfterTestClass
+    void tearDown() {
+        flyway.clean();
+    }
 
     public void migrate(String targetVersion) {
         Flyway flyway = getFlyway(targetVersion);

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/db/template/MigrationTestTemplate.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/db/template/MigrationTestTemplate.java
@@ -3,9 +3,9 @@ package io.twogether.nbe_5_7_2_02team.db.template;
 import org.flywaydb.core.Flyway;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.event.annotation.AfterTestClass;
 
 import javax.sql.DataSource;
-import org.springframework.test.context.event.annotation.AfterTestClass;
 
 @SpringBootTest
 public abstract class MigrationTestTemplate {

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/annotation/FlywayReset.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/annotation/FlywayReset.java
@@ -1,0 +1,18 @@
+package io.twogether.nbe_5_7_2_02team.global.annotation;
+
+import io.twogether.nbe_5_7_2_02team.global.listener.FlywayResetTestExecutionListener;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@TestExecutionListeners(
+    value = {FlywayResetTestExecutionListener.class},
+    mergeMode = MergeMode.MERGE_WITH_DEFAULTS
+)
+public @interface FlywayReset {
+}

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/annotation/FlywayReset.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/annotation/FlywayReset.java
@@ -1,18 +1,18 @@
 package io.twogether.nbe_5_7_2_02team.global.annotation;
 
 import io.twogether.nbe_5_7_2_02team.global.listener.FlywayResetTestExecutionListener;
+
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.TestExecutionListeners.MergeMode;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @TestExecutionListeners(
-    value = {FlywayResetTestExecutionListener.class},
-    mergeMode = MergeMode.MERGE_WITH_DEFAULTS
-)
-public @interface FlywayReset {
-}
+        value = {FlywayResetTestExecutionListener.class},
+        mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
+public @interface FlywayReset {}

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/listener/FlywayResetTestExecutionListener.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/global/listener/FlywayResetTestExecutionListener.java
@@ -1,0 +1,24 @@
+package io.twogether.nbe_5_7_2_02team.global.listener;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+public class FlywayResetTestExecutionListener extends AbstractTestExecutionListener {
+
+    @Override
+    public void beforeTestClass(TestContext testContext) throws Exception {
+        ApplicationContext ac = testContext.getApplicationContext();
+        Flyway flyway = ac.getBean(Flyway.class);
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) throws Exception {
+        ApplicationContext ac = testContext.getApplicationContext();
+        Flyway flyway = ac.getBean(Flyway.class);
+        flyway.clean();
+    }
+}

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/member/service/FollowServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/member/service/FollowServiceTest.java
@@ -1,9 +1,12 @@
 package io.twogether.nbe_5_7_2_02team.member.service;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_DUPLICATION_FOLLOW;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_YOURSELF_FOLLOW;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.twogether.nbe_5_7_2_02team.global.exception.ErrorException;
@@ -22,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
+@FlywayReset
 @SpringBootTest
 @Transactional
 class FollowServiceTest {

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/member/service/FollowServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/member/service/FollowServiceTest.java
@@ -1,14 +1,12 @@
 package io.twogether.nbe_5_7_2_02team.member.service;
 
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_DUPLICATION_FOLLOW;
 import static io.twogether.nbe_5_7_2_02team.global.response.error.ErrorCode.NOT_YOURSELF_FOLLOW;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.global.exception.ErrorException;
 import io.twogether.nbe_5_7_2_02team.member.dao.MemberRepository;
 import io.twogether.nbe_5_7_2_02team.member.domain.Member;

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/tag/service/TagServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/tag/service/TagServiceTest.java
@@ -1,11 +1,10 @@
 package io.twogether.nbe_5_7_2_02team.tag.service;
 
-import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import io.twogether.nbe_5_7_2_02team.tag.dao.TagRepository;
 import io.twogether.nbe_5_7_2_02team.tag.domain.Tag;
-
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/tag/service/TagServiceTest.java
+++ b/NBE_5_7_2_02TEAM/src/test/java/io/twogether/nbe_5_7_2_02team/tag/service/TagServiceTest.java
@@ -1,9 +1,11 @@
 package io.twogether.nbe_5_7_2_02team.tag.service;
 
+import io.twogether.nbe_5_7_2_02team.global.annotation.FlywayReset;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.twogether.nbe_5_7_2_02team.tag.dao.TagRepository;
 import io.twogether.nbe_5_7_2_02team.tag.domain.Tag;
+
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+@FlywayReset
 @SpringBootTest
 @Transactional
 class TagServiceTest {

--- a/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/follow.yml
+++ b/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/follow.yml
@@ -1,0 +1,6 @@
+# member[1] follows member[2]
+
+follow:
+  - id: 1
+    follower_id: 1
+    following_id: 2

--- a/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/member.yml
+++ b/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/member.yml
@@ -1,0 +1,18 @@
+member:
+  - id: 1
+    name: 'backend'
+    github_id: 'be_github'
+    email: 'backend@test.com'
+    job: '백엔드 개발자'
+    course: '데브코스'
+    role: 'MEMBER'
+    created_at: 2025-06-03T15:36:35.223973
+
+  - id: 2
+    name: 'frontend'
+    github_id: 'fe_github'
+    email: 'frontend@test.com'
+    job: '프론트엔드 개발자'
+    course: '데브코스'
+    role: 'MEMBER'
+    created_at: 2025-06-04T15:36:35.223973

--- a/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/post.yml
+++ b/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/post.yml
@@ -1,0 +1,31 @@
+# member[1]: post[1], post[2], post[3]
+# member[2]: post[4]
+
+post:
+  - id: 1
+    title: "TITLE-1"
+    content: "CONTENT-1"
+    recruitment_status: "RECRUITING"
+    member_id: 1
+    created_at: 2025-06-03T15:36:35.223973
+
+  - id: 2
+    title: "TITLE-2"
+    content: "CONTENT-2"
+    recruitment_status: "NONE"
+    member_id: 1
+    created_at: 2025-06-04T15:36:35.223973
+
+  - id: 3
+    title: "TITLE-3"
+    content: "CONTENT-3"
+    recruitment_status: "DONE"
+    member_id: 1
+    created_at: 2025-06-05T15:36:35.223973
+
+  - id: 4
+    title: "TITLE-4"
+    content: "CONTENT-4"
+    recruitment_status: "RECRUITING"
+    member_id: 2
+    created_at: 2025-06-06T15:36:35.223973

--- a/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/tag.yml
+++ b/NBE_5_7_2_02TEAM/src/test/resources/datasets/v2/tag.yml
@@ -1,0 +1,22 @@
+# post[1]: TAG-1
+# post[2]: TAG-1, TAG-2
+
+tag:
+  - id: 1
+    name: "TAG-1"
+
+  - id: 2
+    name: "TAG-2"
+
+post_tag:
+  - id: 1
+    post_id: 1
+    tag_id: 1
+
+  - id: 2
+    post_id: 2
+    tag_id: 1
+
+  - id: 3
+    post_id: 2
+    tag_id: 2


### PR DESCRIPTION
## 관련 이슈

<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

close #98 

## 개요

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

- Browser Test를 DBRider를 이용해 재구성했습니다.
  - 테스트 클래스에서 더 이상 데이터 생성을 진행하지 않고 미리 정의된 데이터셋을 활용합니다.

- 테스트에서 Flyway가 clean 되지 않은 상태에서 migration을 시도해 'xxx table already exists' SQL 에러가 발생하는 문제를 수정했습니다.
  - FlywayReset 어노테이션 인터페이스를 정의해 모든 테스트 클래스에 적용했습니다.
  - 해당 인터페이스는 테스트의 시작 전 Flyway의 정상적인 migration을 보장합니다.